### PR TITLE
Add support for custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ const S3Notifier = require('fastboot-s3-notifier');
 let notifier = new S3Notifier({
   bucket: S3_BUCKET,
   key: S3_KEY,
-  region: AWS_REGION // optional
+  region: AWS_REGION, // optional
+  endpoint: AWS_ENDPOINT_URL // optional
 });
 
 let server = new FastBootAppServer({

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ class S3Notifier {
     this.s3 = new AWS.S3({
       apiVersion: '2006-03-01',
       signatureVersion: 'v4',
-      region: options.region
+      region: options.region,
+      endpoint: options.endpoint
     });
   }
 


### PR DESCRIPTION
Specifying a custom endpoint allows you to use an AWS S3 compatible API like [Minio](https://minio.io) or Digital Ocean's new [Spaces](https://www.digitalocean.com/products/object-storage/) product.