### PR TITLE
Add accessKeyId/secretAccessKey support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ const S3Notifier = require('fastboot-s3-notifier');
 let notifier = new S3Notifier({
   bucket: S3_BUCKET,
   key: S3_KEY,
-  accessKeyId: S3_ACCESS_KEY_ID,
-  secretAccessKey: S3_SECRET_ACCESS_KEY,
-  region: AWS_REGION // optional
+  s3_options: { // optional - any S3 SDK option
+    accessKeyId: S3_ACCESS_KEY_ID,
+    secretAccessKey: S3_SECRET_ACCESS_KEY,
+    region: AWS_REGION
+  }
 });
 
 let server = new FastBootAppServer({

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ const S3Notifier = require('fastboot-s3-notifier');
 let notifier = new S3Notifier({
   bucket: S3_BUCKET,
   key: S3_KEY,
+  accessKeyId: S3_ACCESS_KEY_ID,
+  secretAccessKey: S3_SECRET_ACCESS_KEY,
   region: AWS_REGION // optional
 });
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ class S3Notifier {
     this.s3 = new AWS.S3({
       apiVersion: '2006-03-01',
       signatureVersion: 'v4',
-      region: options.region
+      region: options.region,
+      accessKeyId: options.accessKeyId,
+      secretAccessKey: options.secretAccessKey
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -16,13 +16,10 @@ class S3Notifier {
       Key: this.key
     };
 
-    this.s3 = new AWS.S3({
+    this.s3 = new AWS.S3(Object.assign(options.s3_options || {}, {
       apiVersion: '2006-03-01',
-      signatureVersion: 'v4',
-      region: options.region,
-      accessKeyId: options.accessKeyId,
-      secretAccessKey: options.secretAccessKey
-    });
+      signatureVersion: 'v4'
+    }));
   }
 
   subscribe(notify) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/tomdale/fastboot-s3-notifier#readme",
   "dependencies": {
-    "aws-sdk": "^2.3.4"
+    "aws-sdk": "^2.315.0"
   }
 }


### PR DESCRIPTION
Hi Tom,

This is basically an updated version of #7 and makes fastboot-s3-notifier work with  non-public buckets requiring authentication.

Can you release a new version? This mirrors what was already accepted for fastboot-s3-downloader.

thanks

Luca