### PR TITLE
Intermittent error handling in poll

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,16 +27,16 @@ class S3Notifier {
     this.notify = notify;
 
     return this.getCurrentLastModified()
-      .then(() => this.schedulePoll());
+      .then(() => this.schedulePoll())
+      .catch(() => {
+        this.ui.writeError('error fetching S3 last modified; notifications disabled');
+      });
   }
 
   getCurrentLastModified() {
     return this.s3.headObject(this.params).promise()
       .then(data => {
         this.lastModified = data.LastModified;
-      })
-      .catch(() => {
-        this.ui.writeError('error fetching S3 last modified; notifications disabled');
       });
   }
 

--- a/index.js
+++ b/index.js
@@ -51,6 +51,10 @@ class S3Notifier {
       .then(data => {
         this.compareLastModifieds(data.LastModified);
         this.schedulePoll();
+      })
+      .catch(() => {
+        this.ui.writeError('error fetching S3 last modified; rescheduling');
+        this.schedulePoll();
       });
   }
 


### PR DESCRIPTION
Fixes #13

Also fixes an issue with a case when initial `getCurrentLastModified` fails. Log message suggests that polling process should not be started, which makes sense, but due to how promises were set up it still happened.